### PR TITLE
Fix duplicated description meta tag

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,9 @@ enableRobotsTXT = true
 # https://tailwindcss.com/docs/background-color
 base_color = "bg-gray-800"
 
+#Site description
+description = "Blonde theme for Hugo."
+
 # The number of articles to be displayed on a single page.
 paginator_pages = "5"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,10 +6,6 @@
     <title>{{site.Title}}{{if not .IsHome}} | {{.Title}}{{end}}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-    <meta name="description" content="{{site.Title}}">
-    {{if not .IsHome}}
-    <meta name="description" content="{{ .Description }}">
-    {{end}}
     <link rel="apple-touch-icon" sizes="180x180" href="{{ "/favicon/apple-touch-icon.png" | relURL }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ "/favicon/favicon-32x32.png" | relURL }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ "/favicon/favicon-16x16.png" | relURL }}">


### PR DESCRIPTION
Currently, layouts/partials/head.html and layouts/partials/seo/tags.html have the description meta tag,  this is causing duplicate description meta tags in the page head:

![Screenshot_02](https://user-images.githubusercontent.com/60024333/135722167-9978cad8-a7c6-4325-a03d-6b11191e5184.jpg)

In a post:

![Screenshot_01](https://user-images.githubusercontent.com/60024333/135722165-532c2e49-4209-41a8-9a12-86ac626c5368.jpg)

To solve it, remove the description meta tag from layouts/partials/head.html and add a description section in the params of config.toml.

Then layouts/partials/seo/tags.html will read the site description of the params from config.toml and the description from the post’s front matter.

![Screenshot_03](https://user-images.githubusercontent.com/60024333/135722179-7d00804b-9039-45e1-9863-08ddad633641.jpg)