### PR TITLE
Make dark mode toggle focus state clear for tab users

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="text-white invisible md:visible">
                     <span>|</span>
-                    <button onclick="toggleDarkMode()" class="focus:outline-none" aria-label="Darkmode Toggle Button"><i id="icon2"
+                    <button onclick="toggleDarkMode()" class="focus-visible:outline-none" aria-label="Darkmode Toggle Button"><i id="icon2"
                             class="icon-moon hover:opacity-50 duration-200 inline-flex align-middle leading-normal text-lg ml-2"></i></button>
                 </div>
             </div>


### PR DESCRIPTION
Currently, the focus state for the dark mode toggle is not visible for tab users, which could give the impression that the button is non-interactive due to the `focus:outline-none` class. Instead, I suggest that the `focus-visible:outline-none` should be used.