### PR TITLE
fix hugo err

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,4 +1,4 @@
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 {{ with .Site.GoogleAnalytics }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,5 +1,5 @@
 {{ if not hugo.IsServer }}
-{{ with .Site.GoogleAnalytics }}
+{{ with .Site.Config.Services.GoogleAnalytics.ID }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta property="og:title" content="{{site.Title}}{{if not .IsHome}} | {{.Title}}{{end}}" />
     {{ $styles := resources.Get "css/style.css" | postCSS }}
-    {{ if .Site.IsServer }}
+    {{ if hugo.IsServer }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
     {{ else }}
     {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}

--- a/layouts/partials/seo/print.html
+++ b/layouts/partials/seo/print.html
@@ -42,7 +42,7 @@
 {{- $.Scratch.SetInMap "seo" "twitter_card" "summary_large_image" -}}
 
 {{/* We check the site config sports a Social.twitter and use as handle */}}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.twitter -}}
 	{{- $.Scratch.SetInMap "seo" "twitter_handle" (printf "@%s" .) -}}
 {{- end -}}
 

--- a/layouts/shortcodes/instagram.html
+++ b/layouts/shortcodes/instagram.html
@@ -1,4 +1,4 @@
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
     {{ template "_internal/shortcodes/instagram.html" . }}
 {{ else }}
     <!-- Render the placeholder for the shortcode -->


### PR DESCRIPTION
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use hugo.IsServer instead.
WARN  deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in a future release. Use .Site.Params instead.
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.